### PR TITLE
Improved course progress experience

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -74,6 +74,7 @@ import SearchBar from './SearchBar.vue'
 import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { useProgressStore } from '../store/progress'
+import { curriculum } from '../data/curriculum'
 
 const emit = defineEmits(['toggle-mobile-menu'])
 const router = useRouter()
@@ -118,13 +119,34 @@ const handleResize = () => {
 }
 
 const goToCurrentProgress = () => {
-  router.push({
-    name: 'lesson',
-    params: {
-      sectionId: progressStore.currentLesson.section + 1,
-      lessonId: progressStore.currentLesson.lesson + 1,
-    },
-  })
+  const nextItem = progressStore.nextUncompletedItem
+  if (nextItem) {
+    if (nextItem.type === 'lesson') {
+      router.push({
+        name: 'lesson',
+        params: {
+          sectionId: nextItem.section + 1,
+          lessonId: nextItem.lesson + 1,
+        },
+      })
+    } else if (nextItem.type === 'challenge') {
+      router.push({
+        name: 'challenge',
+        params: {
+          sectionId: nextItem.section + 1,
+        },
+      })
+    }
+  } else {
+    // If all items are completed, go to the last challenge
+    const lastSectionIndex = curriculum.length - 1
+    router.push({
+      name: 'challenge',
+      params: {
+        sectionId: lastSectionIndex + 1,
+      },
+    })
+  }
 }
 
 const toggleMobileMenu = () => {


### PR DESCRIPTION
Nothing is more satisfying then seeing progress. So I:

1. Greatly improved the visual progress feedback on the section cards, on the Home page. Users can at a glance see what is completed, and what isnt.
2. Also fixed the simple Continue logic to look at all Sections and lessons, and go to the first lesson not completed, and if all lessons completed, go to the section challenge. If all lessons and the challenge is completed, then to move to the next section in the curriculum and repeat the progress. This is significant because some users may start several sections at once, so the continue will always bring them back to the first incomplete section!