### PR TITLE
Added CORS support for Vercel

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "javascript-job-prepper-api",
+  "version": "1.1.0",
+  "description": "API endpoints for JavaScript Job Prepper",
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}

--- a/api/proxy.js
+++ b/api/proxy.js
@@ -1,0 +1,50 @@
+import axios from 'axios'
+
+// Middleware to enable CORS
+const allowCors = (fn) => async (req, res) => {
+  res.setHeader('Access-Control-Allow-Credentials', true)
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization, x-api-key, anthropic-version',
+  )
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  return await fn(req, res)
+}
+
+// Handler function for the proxy
+const handler = async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { target, data, headers } = req.body
+
+  if (!target) {
+    return res.status(400).json({ error: 'Target URL is required' })
+  }
+
+  try {
+    const response = await axios({
+      method: 'post',
+      url: target,
+      data: data,
+      headers: headers,
+    })
+
+    return res.status(response.status).json(response.data)
+  } catch (error) {
+    const statusCode = error.response?.status || 500
+    const errorData = error.response?.data || { error: error.message }
+
+    return res.status(statusCode).json(errorData)
+  }
+}
+
+export default allowCors(handler)

--- a/src/utils/aiService.js
+++ b/src/utils/aiService.js
@@ -17,6 +17,9 @@ const API_ENDPOINTS = {
   other: 'custom-endpoint', // This will be overridden with the user's custom endpoint
 }
 
+// Proxy API endpoint URL
+const PROXY_API_URL = '/api/proxy'
+
 // AI model mappings (export so we can hook into the models in the UI)
 export const MODEL_MAPPINGS = {
   'claude-3-5-sonnet': 'claude-3-5-sonnet-20240620',
@@ -297,7 +300,13 @@ export const submitCodeForGrading = async (
   const headers = getHeaders(provider, apiKey, customHeaders)
 
   try {
-    const response = await axios.post(endpoint, requestData, { headers })
+    // Use our proxy endpoint instead of calling the API directly
+    const response = await axios.post(PROXY_API_URL, {
+      target: endpoint,
+      data: requestData,
+      headers: headers,
+    })
+
     const responseText = extractResponseText(provider, response.data)
     return responseText
   } catch (error) {
@@ -407,7 +416,13 @@ export const testApiConnection = async (
   const headers = getHeaders(provider, apiKey, customHeaders)
 
   try {
-    const response = await axios.post(endpoint, requestData, { headers })
+    // Use our proxy endpoint instead of calling the API directly
+    const response = await axios.post(PROXY_API_URL, {
+      target: endpoint,
+      data: requestData,
+      headers: headers,
+    })
+
     return !!response.data // Return true if we got any response
   } catch (error) {
     console.error('API connection test failed:', error)

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Credentials", "value": "true" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization, x-api-key, anthropic-version"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

## Fixed CORS issues with AI provider API calls | Vercel deploys only

This PR addresses the CORS issues encountered when making API calls to third-party AI providers from the client-side application hosted on Vercel.

### Changes implemented:
- Created a server-side proxy endpoint (`/api/proxy.js`) that forwards requests to AI providers
- Added proper CORS headers configuration in `vercel.json`
- Modified `aiService.js` to route all API calls through the proxy instead of direct calls
- Added necessary dependencies for the API function

This solution prevents browser CORS restrictions by handling all third-party API calls on the server side rather than directly from the client.
