### PR TITLE
Added AI Chat Streaming, UI improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bootstrap-vue-3": "^0.3.12",
     "canvas-confetti": "^1.9.3",
     "js-cookie": "^3.0.5",
+    "marked": "^15.0.12",
     "pinia": "^3.0.1",
     "prismjs": "^1.30.0",
     "vue": "^3.5.13",

--- a/src/components/AIChat.vue
+++ b/src/components/AIChat.vue
@@ -129,11 +129,10 @@
             <div v-if="!aiChatStore.apiKey" class="api-key-warning">
               <i class="bi bi-exclamation-triangle-fill me-2"></i>
               <span
-                >You need to
+                >You need to configure an API key in settings to get started.
                 <button @click="showSettings = true" class="btn-link">
-                  configure an API key <i class="bi bi-gear"></i>
+                  <i class="bi bi-gear"></i> Configure Settings
                 </button>
-                in settings to get started
               </span>
             </div>
           </div>
@@ -147,8 +146,8 @@
             />
           </template>
 
-          <!-- Chat Message Loading Indicator -->
-          <div v-if="aiChatStore.isSending" class="typing-indicator">
+          <!-- Chat Message Loading Indicator (only show for non-streaming) -->
+          <div v-if="aiChatStore.isSending && !aiChatStore.useStreaming" class="typing-indicator">
             <div class="dot"></div>
             <div class="dot"></div>
             <div class="dot"></div>
@@ -281,11 +280,11 @@ const cancelConfirmDialog = () => {
   actionData.value = null
 }
 
-// Send a message to the AI
+// Send userss message to the AI
 const sendMessage = async (content) => {
   if (!content || !aiChatStore.apiKey) return
 
-  // Include the current topic in the conversation context
+  // Include the current topic in the conversation context (Context for the LLM)
   if (aiChatStore.conversationContext) {
     aiChatStore.conversationContext += `\nCurrent topic: ${currentTopicName.value}`
   } else {
@@ -294,12 +293,12 @@ const sendMessage = async (content) => {
 
   await aiChatStore.sendMessage(content, currentTopicName.value)
 
-  // Scroll to bottom after sending
+  // keep the chat scrolled to the bottom.
   await nextTick()
   scrollToBottom()
 }
 
-// Scroll to the bottom of messages
+// We could make this a config option for users to toggle
 const scrollToBottom = () => {
   if (messagesContainer.value) {
     const container = messagesContainer.value
@@ -317,7 +316,22 @@ watch(
   },
 )
 
-// Handle clicks outside the dropdown to close it
+// Watch for streaming message content changes
+watch(
+  () => {
+    const streamingMessage = aiChatStore.messages.find(
+      (msg) => msg.id === aiChatStore.streamingMessageId,
+    )
+    return streamingMessage?.content
+  },
+  () => {
+    nextTick(() => {
+      scrollToBottom()
+    })
+  },
+)
+
+// Handle clicks outside element, close it
 const handleClickOutside = (event) => {
   const dropdown = document.querySelector('.conversations-dropdown')
   if (dropdown && !dropdown.contains(event.target) && dropdownOpen.value) {
@@ -332,7 +346,6 @@ const handleResize = () => {
 
 // Set conversation context based on page content
 const setContextFromPage = () => {
-  // Find the section title and topic if available
   const sectionTitle = document.querySelector('.section-title, .challenge-title')
   const lessonTitle = document.querySelector('.lesson-title')
 
@@ -346,10 +359,9 @@ const setContextFromPage = () => {
     context += `Lesson: ${lessonTitle.textContent.trim()}\n`
   }
 
-  // Try to get lesson content
+  // Get trimmed lesson content (Context for the LLM)
   const lessonContent = document.querySelector('.lesson-content, .challenge-description')
   if (lessonContent) {
-    // Limit content length
     let contentText = lessonContent.textContent.trim()
     if (contentText.length > 500) {
       contentText = contentText.substring(0, 500) + '...'
@@ -367,23 +379,18 @@ onMounted(() => {
   if (!aiChatStore.isLoaded) {
     aiChatStore.loadSettings()
   }
-
-  // Add resize listener
   window.addEventListener('resize', handleResize)
-
-  // Add click event listener to close dropdown when clicking outside
   document.addEventListener('click', handleClickOutside)
 
-  // Set initial context
+  // Set iniial context
   setContextFromPage()
 
   scrollToBottom()
 })
 
 onUnmounted(() => {
-  // Remove resize listener when component is unmounted
+  // Cleanup
   window.removeEventListener('resize', handleResize)
-  // Remove click outside listener
   document.removeEventListener('click', handleClickOutside)
 })
 </script>

--- a/src/components/AIChat.vue
+++ b/src/components/AIChat.vue
@@ -382,7 +382,7 @@ onMounted(() => {
   window.addEventListener('resize', handleResize)
   document.addEventListener('click', handleClickOutside)
 
-  // Set iniial context
+  // Set initial context
   setContextFromPage()
 
   scrollToBottom()

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -4,7 +4,6 @@
       <div class="header-content">
         <!-- Left section: Logo, menu toggle and title -->
         <div class="header-left">
-          <!-- Mobile menu toggle button -->
           <div class="mobile-menu-toggle d-md-none" @click="toggleMobileMenu">
             <i class="bi" :class="mobileMenuOpen ? 'bi-x-lg' : 'bi-list'"></i>
           </div>
@@ -65,7 +64,6 @@
 
         <!-- Right section: Theme toggle, Progress, Continue, and mobile search icon -->
         <div class="header-right">
-          <!-- Mobile Topic Selector -->
           <div class="mobile-topic-selector d-md-none">
             <select
               v-model="selectedTopic"
@@ -124,7 +122,7 @@ const topicStore = useTopicStore()
 const mobileMenuOpen = ref(false)
 const searchExpanded = ref(false)
 const windowWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1024)
-const selectedTopic = ref('javascript') // Added ref for topic selection
+const selectedTopic = ref('javascript') // We default to javascript for now, when home page is loaded
 
 // Define props to receive mobile menu state from App.vue
 const props = defineProps({
@@ -142,7 +140,15 @@ watch(
   },
 )
 
-// Check if there's any user progress to determine if we should show the continue button
+// Watch for topic changes from the store
+watch(
+  () => topicStore.currentTopic,
+  (newTopic) => {
+    selectedTopic.value = newTopic
+  },
+)
+
+// Check for course progress, conditionallyshow the continue button
 const hasProgress = computed(() => {
   return (
     progressStore.currentLesson &&
@@ -152,7 +158,6 @@ const hasProgress = computed(() => {
 })
 
 onMounted(() => {
-  // set progress state
   if (!progressStore.isLoaded) {
     progressStore.loadProgress()
   }
@@ -187,10 +192,8 @@ const handleResize = () => {
 const changeTopic = () => {
   // Only take action if there's actually a change
   if (selectedTopic.value !== topicStore.currentTopic) {
-    // Set the new topic
     topicStore.setTopic(selectedTopic.value)
 
-    // Always navigate to home page when switching topics
     router.push('/')
   }
 }
@@ -216,7 +219,6 @@ const goToCurrentProgress = async () => {
         })
       }
     } else {
-      // If all items are completed, navigate to home
       router.push('/')
     }
   } catch (error) {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -148,7 +148,7 @@ watch(
   },
 )
 
-// Check for course progress, conditionallyshow the continue button
+// Conditionally show the continue button
 const hasProgress = computed(() => {
   return (
     progressStore.currentLesson &&

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -111,6 +111,7 @@ watch(
 .message-textarea:focus {
   box-shadow: 0 0 0 0.25rem rgba(var(--primary-color-rgb), 0.25);
   border-color: var(--primary-color);
+  color: var(--text-color);
 }
 
 .message-textarea::placeholder {
@@ -118,11 +119,20 @@ watch(
   opacity: 0.6;
 }
 
+/* AI Chatbot specific, style fixes for dark mode */
+:root[data-theme='dark'] .message-textarea {
+  color: #ffffff;
+}
+
+:root[data-theme='dark'] .message-textarea:focus {
+  color: #ffffff;
+}
+
 .send-button {
   position: absolute;
   bottom: 8px;
   right: 10px;
-  background-color: var(--primary-color);
+  background-color: #36bf8d;
   color: white;
   border: none;
   border-radius: 50%;

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -12,6 +12,7 @@
       </div>
       <div class="message-body" v-if="role === 'assistant' || role === 'system'">
         <div v-html="formattedContent" class="markdown-content"></div>
+        <span v-if="isStreaming" class="typing-cursor"></span>
       </div>
       <div class="message-body" v-else>
         {{ message.content }}
@@ -22,7 +23,10 @@
 
 <script setup>
 import { computed } from 'vue'
-import { formatMarkdown } from '../theme/markdownFormatter'
+import { formatMarkdown, resetStreamingState } from '../theme/markdownFormatter'
+import { useAIChatStore } from '../store/aiChat'
+
+const aiChatStore = useAIChatStore()
 
 const props = defineProps({
   message: {
@@ -51,7 +55,12 @@ const messageClass = computed(() => {
     'user-message': role.value === 'user',
     'assistant-message': role.value === 'assistant',
     'system-message': role.value === 'system',
+    'streaming-message': isStreaming.value,
   }
+})
+
+const isStreaming = computed(() => {
+  return props.message.id === aiChatStore.streamingMessageId
 })
 
 const formattedTime = computed(() => {
@@ -70,7 +79,13 @@ const formattedTime = computed(() => {
 })
 
 const formattedContent = computed(() => {
-  return formatMarkdown(props.message.content)
+  // Reset streaming state when message changes
+  if (props.message.id !== aiChatStore.streamingMessageId) {
+    resetStreamingState()
+  }
+
+  // Format the message
+  return formatMarkdown(props.message.content, isStreaming.value)
 })
 </script>
 
@@ -95,6 +110,31 @@ const formattedContent = computed(() => {
 .system-message {
   background-color: rgba(var(--warning-color-rgb), 0.1);
   border-left: 3px solid var(--warning-color);
+}
+
+.streaming-message {
+  border-left: 3px solid var(--primary-color);
+  position: relative;
+}
+
+.streaming-message::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--primary-color) 0%, transparent 100%);
+  animation: streaming-progress 1s infinite linear;
+}
+
+@keyframes streaming-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .message-content {
@@ -145,6 +185,27 @@ const formattedContent = computed(() => {
   line-height: 1.5;
   overflow-wrap: break-word;
   word-break: break-word;
+  position: relative;
+}
+
+.typing-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 16px;
+  background-color: var(--primary-color);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink 1s infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 
 :deep(.markdown-content) {
@@ -188,5 +249,26 @@ const formattedContent = computed(() => {
   border-radius: 3px;
   font-size: 0.9em;
   border: 1px solid rgba(var(--primary-color-rgb), 0.2);
+}
+
+/* Streaming message styles */
+:deep(.streaming-code) {
+  background-color: var(--bg-code);
+  padding: 12px;
+  border-radius: 6px;
+  font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 0.9em;
+  color: var(--text-muted);
+  border: 1px dashed var(--border-color);
+}
+
+:deep(.streaming-bold) {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+:deep(.streaming-italic) {
+  font-style: italic;
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -11,14 +11,6 @@
         placeholder="Paste your code here..."
       ></textarea>
     </div>
-    <div class="editor-preview" v-if="code">
-      <h5>Preview:</h5>
-      <div class="preview-container">
-        <pre
-          class="limited-height-preview"
-        ><code class="language-javascript" v-html="highlightedCode"></code></pre>
-      </div>
-    </div>
     <div class="editor-footer">
       <button @click="saveCode" class="btn btn-primary">Save</button>
       <button
@@ -82,15 +74,7 @@ onMounted(() => {
   if (props.isChallenge) {
     const savedResponse = aiStore.getSavedResponse(props.sectionId)
     if (savedResponse) {
-      // Restore saved response
       aiStore.setLastResponse(savedResponse.response)
-
-      // If there's a code sample that doesn't match the current code, we could
-      // show a notice to the user asking if they want to restore it
-      if (savedResponse.code && code.value !== savedResponse.code && !code.value) {
-        // This is optional - you could add a UI element to restore the code
-        // For now, let's just keep their current code
-      }
     }
   }
 })
@@ -106,22 +90,7 @@ watch(code, () => {
   highlightCode()
 })
 
-// Function to escape HTML in the code
-const escapeHtml = (unsafe) => {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;')
-}
-
-// Computed property for highlighted code
-const highlightedCode = computed(() => {
-  return escapeHtml(code.value)
-})
-
-// Function to apply Prism highlighting
+// Apply Prism highlighting
 const highlightCode = () => {
   setTimeout(() => {
     Prism.highlightAll()
@@ -148,7 +117,6 @@ const saveCode = () => {
 }
 
 const submitAndGradeCode = async () => {
-  // First save the code
   const savedCode = saveCode()
 
   // Mark as completed
@@ -167,7 +135,7 @@ const submitAndGradeCode = async () => {
     aiStore.setLoading(true)
 
     try {
-      // Get the current section or lesson details
+      // Get the current section or lesson details (Context for the LLM)
       let sectionTitle, challengeDescription
 
       if (props.isChallenge) {
@@ -179,7 +147,6 @@ const submitAndGradeCode = async () => {
           challengeDescription = section.challenge?.description || 'Complete the coding challenge'
         }
       } else {
-        // Handle lesson grading if needed in the future
         const sectionIndex = props.sectionId - 1
         const lessonIndex = props.lessonId - 1
         const section = window.curriculum?.[sectionIndex]
@@ -191,7 +158,7 @@ const submitAndGradeCode = async () => {
         }
       }
 
-      // Submit the code for grading
+      // Submit the code for grading (prompt context for the LLM)
       const response = await submitCodeForGrading(
         aiStore.provider,
         aiStore.apiKey,
@@ -204,7 +171,7 @@ const submitAndGradeCode = async () => {
         aiStore.customHeaders,
       )
 
-      // Store the AI response
+      // Set the AI response
       aiStore.setLastResponse(response)
 
       // Save the response to localStorage
@@ -271,12 +238,6 @@ const resetCode = () => {
   background-color: #171717;
   color: var(--text-light);
   transition: all var(--transition-speed) ease;
-}
-
-.editor-preview {
-  padding: 10px;
-  border-top: 1px solid var(--border-color);
-  background-color: var(--bg-sidebar);
 }
 
 .preview-container {

--- a/src/store/aiChat.js
+++ b/src/store/aiChat.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { saveToStorage, loadFromStorage } from '../utils/storage'
-import { sendChatMessage } from '../utils/aiChatService'
+import { sendChatMessage, streamChatMessage } from '../utils/aiChatService'
 
 const STORAGE_KEY = 'js_job_prepper_chat_settings'
 const CONVERSATIONS_STORAGE_KEY = 'js_job_prepper_chat_conversations'
@@ -29,21 +29,76 @@ export const useAIChatStore = defineStore('aiChat', {
     activeConversationId: 'default',
     conversationContext: '',
     termsAccepted: false,
+    streamingMessageId: null,
+    useStreaming: true,
   }),
 
   getters: {
     availableProviders() {
       return [
-        { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo' },
-        { value: 'gpt-4', label: 'GPT-4 Turbo' },
-        { value: 'gpt-4o', label: 'GPT-4o' },
         { value: 'claude-3-5-sonnet', label: 'Claude 3.5 Sonnet' },
         { value: 'claude-3-7-sonnet', label: 'Claude 3.7 Sonnet' },
         { value: 'claude-3-opus', label: 'Claude 3 Opus' },
+        { value: 'claude-3-haiku', label: 'Claude 3 Haiku' },
+        { value: 'claude-opus-4', label: 'Claude Opus 4' },
+        { value: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+        { value: 'gpt-4', label: 'GPT-4 Turbo' },
+        { value: 'gpt-4o', label: 'GPT-4o' },
+        { value: 'gpt-4.5', label: 'GPT-4.5' },
+        { value: 'gpt-o1', label: 'GPT-o1' },
+        { value: 'gpt-o3', label: 'GPT-o3' },
+        { value: 'gpt-o4-mini', label: 'GPT-o4 Mini' },
+        { value: 'deepseek-reasoner', label: 'DeepSeek-R1' },
+        { value: 'deepseek-r1-distill', label: 'DeepSeek R1 Distill' },
+        { value: 'grok-3', label: 'Grok 3' },
         { value: 'mistral-large', label: 'Mistral Large' },
+        { value: 'mistral-large-2', label: 'Mistral Large 2' },
+        { value: 'llama-3', label: 'Llama 3' },
+        { value: 'llama-3.1', label: 'Llama 3.1' },
+        { value: 'llama-3.2', label: 'Llama 3.2' },
         { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
+        { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+        { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+        { value: 'qwen-2.5', label: 'Qwen 2.5' },
+        { value: 'cohere-command-r-plus', label: 'Cohere Command R+' },
+        { value: 'ollama', label: 'Ollama (Local)' },
         { value: 'other', label: 'Other...' },
       ]
+    },
+
+    providerEndpoints() {
+      return {
+        'gpt-4': 'https://api.openai.com/v1/chat/completions',
+        'gpt-4o': 'https://api.openai.com/v1/chat/completions',
+        'gpt-4.5': 'https://api.openai.com/v1/chat/completions',
+        'gpt-o1': 'https://api.openai.com/v1/chat/completions',
+        'gpt-o3': 'https://api.openai.com/v1/chat/completions',
+        'gpt-o4-mini': 'https://api.openai.com/v1/chat/completions',
+        'claude-3-5-sonnet': 'https://api.anthropic.com/v1/messages',
+        'claude-3-7-sonnet': 'https://api.anthropic.com/v1/messages',
+        'claude-3-opus': 'https://api.anthropic.com/v1/messages',
+        'claude-3-haiku': 'https://api.anthropic.com/v1/messages',
+        'claude-opus-4': 'https://api.anthropic.com/v1/messages',
+        'claude-sonnet-4': 'https://api.anthropic.com/v1/messages',
+        'gemini-1.5-pro':
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent',
+        'gemini-2.5-pro':
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent',
+        'gemini-2.5-flash':
+          'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+        'deepseek-reasoner': 'https://api.deepseek.com/v1/chat/completions',
+        'deepseek-r1-distill': 'https://api.deepseek.com/v1/chat/completions',
+        'grok-3': 'https://api.x.ai/v1/chat/completions',
+        'mistral-large': 'https://api.mistral.ai/v1/chat/completions',
+        'mistral-large-2': 'https://api.mistral.ai/v1/chat/completions',
+        'qwen-2.5':
+          'https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation',
+        'cohere-command-r-plus': 'https://api.cohere.ai/v1/generate',
+        'llama-3': 'https://api.together.xyz/v1/chat/completions',
+        'llama-3.1': 'https://api.together.xyz/v1/chat/completions',
+        'llama-3.2': 'https://api.together.xyz/v1/chat/completions',
+        ollama: 'http://localhost:11434/api/generate',
+      }
     },
 
     currentProviderLabel() {
@@ -94,6 +149,7 @@ export const useAIChatStore = defineStore('aiChat', {
         systemPrompt: this.systemPrompt,
         termsAccepted: this.termsAccepted,
         activeConversationId: this.activeConversationId,
+        useStreaming: this.useStreaming,
       }
 
       saveToStorage(data, STORAGE_KEY)
@@ -112,6 +168,7 @@ export const useAIChatStore = defineStore('aiChat', {
         this.systemPrompt = data.systemPrompt || ''
         this.termsAccepted = data.termsAccepted || false
         this.activeConversationId = data.activeConversationId || 'default'
+        this.useStreaming = data.useStreaming !== undefined ? data.useStreaming : true
       }
 
       // finally load conversations
@@ -149,6 +206,10 @@ export const useAIChatStore = defineStore('aiChat', {
 
     setProvider(provider) {
       this.provider = provider
+
+      if (provider === 'ollama') {
+        this.version = ''
+      }
       this.saveSettings()
     },
 
@@ -184,6 +245,11 @@ export const useAIChatStore = defineStore('aiChat', {
 
     acceptTerms() {
       this.termsAccepted = true
+      this.saveSettings()
+    },
+
+    setTermsAccepted(value) {
+      this.termsAccepted = value
       this.saveSettings()
     },
 
@@ -255,10 +321,17 @@ export const useAIChatStore = defineStore('aiChat', {
       const conversation = this.conversations.find((c) => c.id === this.activeConversationId)
 
       if (conversation) {
-        // Add the message to the active conversation
-        conversation.messages.push({ role, content, timestamp: new Date().toISOString() })
+        // Create a message object with a unique ID
+        const messageId = `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+        const message = {
+          id: messageId,
+          role,
+          content,
+          timestamp: new Date().toISOString(),
+        }
 
-        // Update conversation timestamp
+        // Add the message to the active conversation
+        conversation.messages.push(message)
         conversation.timestamp = new Date().toISOString()
 
         // Update conversation title based on first user message if it's "New Conversation"
@@ -268,6 +341,53 @@ export const useAIChatStore = defineStore('aiChat', {
         }
 
         this.saveConversations()
+
+        return messageId
+      }
+
+      return null
+    },
+
+    // Create initial streaming message
+    startStreamingMessage() {
+      const messageId = this.addMessage('assistant', '')
+      this.streamingMessageId = messageId
+      return messageId
+    },
+
+    // Update streaming message content
+    updateStreamingMessage(content) {
+      if (!this.streamingMessageId) return
+
+      const conversation = this.conversations.find((c) => c.id === this.activeConversationId)
+      if (!conversation) return
+
+      const message = conversation.messages.find((msg) => msg.id === this.streamingMessageId)
+      if (message) {
+        message.content += content
+        // Occasionally save if the content gets long
+        if (message.content.length % 500 === 0) {
+          this.saveConversations()
+        }
+      }
+    },
+
+    // Finalize streaming message
+    finalizeStreamingMessage(fullContent) {
+      if (!this.streamingMessageId) return
+
+      const conversation = this.conversations.find((c) => c.id === this.activeConversationId)
+      if (!conversation) return
+
+      const message = conversation.messages.find((msg) => msg.id === this.streamingMessageId)
+      if (message) {
+        // complete content if available
+        if (fullContent) {
+          message.content = fullContent
+        }
+
+        this.saveConversations()
+        this.streamingMessageId = null
       }
     },
 
@@ -293,24 +413,53 @@ export const useAIChatStore = defineStore('aiChat', {
       this.clearError()
 
       try {
-        // Send message to AI API as configured by user in the settings tab of chat bot
-        const response = await sendChatMessage(
-          messagesToSend,
-          this.provider,
-          this.apiKey,
-          this.systemPrompt || undefined,
-          this.version,
-          this.customModel,
-          this.customEndpoint,
-          this.customHeaders,
-          topic,
-        )
+        if (this.useStreaming) {
+          this.startStreamingMessage()
 
-        // Add response to messages
-        this.addMessage('assistant', response)
+          // Stream the message in real-time
+          const fullResponse = await streamChatMessage(
+            messagesToSend,
+            this.provider,
+            this.apiKey,
+            this.systemPrompt || undefined,
+            this.version,
+            this.customModel,
+            this.customEndpoint,
+            this.customHeaders,
+            topic,
+            // Callback each chunk
+            (chunk) => {
+              this.updateStreamingMessage(chunk)
+            },
+          )
+
+          // Finalize completed response
+          this.finalizeStreamingMessage(fullResponse)
+        } else {
+          // Fall back to non-streaming approach (user can toggle this in the settings)
+          const response = await sendChatMessage(
+            messagesToSend,
+            this.provider,
+            this.apiKey,
+            this.systemPrompt || undefined,
+            this.version,
+            this.customModel,
+            this.customEndpoint,
+            this.customHeaders,
+            topic,
+          )
+
+          this.addMessage('assistant', response)
+        }
       } catch (error) {
         console.error('Failed to send message:', error)
         this.setError(error.message || 'Failed to send message')
+
+        // error message if streaming
+        if (this.streamingMessageId) {
+          this.finalizeStreamingMessage('')
+        }
+
         this.addMessage('system', `Error: ${error.message || 'Failed to get response'}`)
       } finally {
         this.isSending = false
@@ -349,6 +498,18 @@ export const useAIChatStore = defineStore('aiChat', {
       this.customHeaders = ''
       this.version = ''
       this.systemPrompt = ''
+      this.saveSettings()
+    },
+
+    // Toggle streaming mode on/off
+    toggleStreaming() {
+      this.useStreaming = !this.useStreaming
+      this.saveSettings()
+    },
+
+    // Update streaming setting
+    setStreaming(value) {
+      this.useStreaming = value
       this.saveSettings()
     },
   },

--- a/src/store/topic.js
+++ b/src/store/topic.js
@@ -101,7 +101,6 @@ export const useTopicStore = defineStore('topic', {
 
     // Update the initializeTopics method to include default topics
     async initializeTopics() {
-      // First, ensure all pre-defined topics are included
       const defaultTopics = ['javascript', 'csharp', 'ai', 'typescript', 'react', 'devops']
       for (const topic of defaultTopics) {
         if (!this.topicsWithCurriculum.includes(topic)) {
@@ -109,13 +108,10 @@ export const useTopicStore = defineStore('topic', {
         }
       }
 
-      // Then check all available topics for curriculum
+      // available topics for curriculum
       for (const topic of this.availableTopics) {
         await this.checkTopicCurriculum(topic.value)
       }
-
-      // For debugging - log which topics have curriculum
-      console.log('Topics with curriculum:', this.topicsWithCurriculum)
     },
   },
 })

--- a/src/utils/aiChatService.js
+++ b/src/utils/aiChatService.js
@@ -2,27 +2,90 @@ import axios from 'axios'
 
 // Base endpoints for different AI providers
 const API_ENDPOINTS = {
+  // Anthropic Models
   'claude-3-5-sonnet': 'https://api.anthropic.com/v1/messages',
   'claude-3-7-sonnet': 'https://api.anthropic.com/v1/messages',
   'claude-3-opus': 'https://api.anthropic.com/v1/messages',
+  'claude-3-haiku': 'https://api.anthropic.com/v1/messages',
+  'claude-opus-4': 'https://api.anthropic.com/v1/messages',
+  'claude-sonnet-4': 'https://api.anthropic.com/v1/messages',
+
+  // OpenAI Models
+  'gpt-3.5-turbo': 'https://api.openai.com/v1/chat/completions',
   'gpt-4': 'https://api.openai.com/v1/chat/completions',
   'gpt-4o': 'https://api.openai.com/v1/chat/completions',
-  'gpt-3.5-turbo': 'https://api.openai.com/v1/chat/completions',
+  'gpt-4.5': 'https://api.openai.com/v1/chat/completions',
+  'gpt-o1': 'https://api.openai.com/v1/chat/completions',
+  'gpt-o3': 'https://api.openai.com/v1/chat/completions',
+  'gpt-o4-mini': 'https://api.openai.com/v1/chat/completions',
+
+  // Google Models
+  'gemini-1.5-pro':
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent',
+  'gemini-2.5-pro':
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent',
+  'gemini-2.5-flash':
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+
+  // Other Models
+  'deepseek-reasoner': 'https://api.deepseek.com/v1/chat/completions',
+  'deepseek-r1-distill': 'https://api.deepseek.com/v1/chat/completions',
+  'grok-3': 'https://api.x.ai/v1/chat/completions',
   'mistral-large': 'https://api.mistral.ai/v1/chat/completions',
-  'gemini-1.5-pro': 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro',
+  'mistral-large-2': 'https://api.mistral.ai/v1/chat/completions',
+  'qwen-2.5': 'https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation',
+  'cohere-command-r-plus': 'https://api.cohere.ai/v1/generate',
+
+  // Meta Models (via Together AI)
+  'llama-3': 'https://api.together.xyz/v1/chat/completions',
+  'llama-3.1': 'https://api.together.xyz/v1/chat/completions',
+  'llama-3.2': 'https://api.together.xyz/v1/chat/completions',
+
+  // Local
+  ollama: 'http://localhost:11434/api/generate',
   other: 'custom-endpoint',
 }
 
 // AI model mappings
 export const CHAT_MODEL_MAPPINGS = {
+  // Anthropic Models
   'claude-3-5-sonnet': 'claude-3-5-sonnet-20240620',
   'claude-3-7-sonnet': 'claude-3-7-sonnet-20250219',
   'claude-3-opus': 'claude-3-opus-20240229',
+  'claude-3-haiku': 'claude-3-haiku-20240307',
+  'claude-opus-4': 'claude-3-opus-20240229',
+  'claude-sonnet-4': 'claude-3-5-sonnet-20240620',
+
+  // OpenAI Models
+  'gpt-3.5-turbo': 'gpt-3.5-turbo-0613',
   'gpt-4': 'gpt-4-turbo-2024-04-09',
   'gpt-4o': 'gpt-4o-2024-05-13',
-  'gpt-3.5-turbo': 'gpt-3.5-turbo-0613',
-  'mistral-large': 'mistral-large-latest',
+  'gpt-4.5': 'gpt-4o-mini-2024-07-18',
+  'gpt-o1': 'gpt-o1-2024-05-13',
+  'gpt-o3': 'gpt-o3-2024-07-18',
+  'gpt-o4-mini': 'gpt-o4-mini-2024-07-18',
+
+  // Google Models
   'gemini-1.5-pro': 'gemini-1.5-pro-latest',
+  'gemini-2.5-pro': 'gemini-2.5-pro-latest',
+  'gemini-2.5-flash': 'gemini-2.5-flash-latest',
+
+  // Other Models
+  'deepseek-reasoner': 'deepseek-reasoner:latest',
+  'deepseek-r1-distill': 'deepseek-r1-distill:latest',
+  'grok-3': 'grok-3',
+  'mistral-large': 'mistral-large-latest',
+  'mistral-large-2': 'mistral-large-2-latest',
+  'qwen-2.5': 'qwen2.5-72b-instruct',
+  'cohere-command-r-plus': 'command-r-plus',
+
+  // Meta Models
+  'llama-3': 'meta-llama/Llama-3-70b-chat-hf',
+  'llama-3.1': 'meta-llama/Llama-3.1-70b-chat-hf',
+  'llama-3.2': 'meta-llama/Llama-3.2-70b-chat-hf',
+
+  // Local
+  ollama: 'llama2',
   other: 'custom-model',
 }
 
@@ -49,6 +112,202 @@ Format your responses using markdown for readability.`
 // Default system prompt for backwards compatibility
 const DEFAULT_SYSTEM_PROMPT = getSystemPrompt()
 
+// Ollama Stream Handler for model-specific streaming support
+class OllamaStreamHandler {
+  constructor() {
+    // Model-specific configurations
+    this.modelConfigs = {
+      gemma: {
+        responseField: 'response',
+        requiresSpecialParsing: true,
+        markdownMode: 'tolerant',
+        chunkDelimiter: '\n',
+        filterMetadata: false,
+      },
+      qwen: {
+        responseField: 'response',
+        requiresSpecialParsing: false,
+        markdownMode: 'standard',
+        chunkDelimiter: '\n',
+        filterMetadata: true, // Enable metadata filtering for Qwen
+        metadataFields: ['model', 'createdat', 'done'], // Fields to filter out
+      },
+      deepseek: {
+        responseField: 'response',
+        requiresSpecialParsing: true,
+        markdownMode: 'code-aware',
+        chunkDelimiter: '\n',
+        filterMetadata: false,
+      },
+      llama: {
+        responseField: 'response',
+        requiresSpecialParsing: false,
+        markdownMode: 'standard',
+        chunkDelimiter: '\n',
+        filterMetadata: false,
+      },
+      mistral: {
+        responseField: 'response',
+        requiresSpecialParsing: false,
+        markdownMode: 'standard',
+        chunkDelimiter: '\n',
+        filterMetadata: false,
+      },
+    }
+  }
+
+  // Detect model type from model name
+  detectModelType(modelName) {
+    const lowercaseName = modelName.toLowerCase()
+    if (lowercaseName.includes('gemma')) return 'gemma'
+    if (lowercaseName.includes('qwen')) return 'qwen'
+    if (lowercaseName.includes('deepseek')) return 'deepseek'
+    if (lowercaseName.includes('llama')) return 'llama'
+    if (lowercaseName.includes('mistral')) return 'mistral'
+    return 'default'
+  }
+
+  // Get configuration for the detected model
+  getModelConfig(modelName) {
+    const modelType = this.detectModelType(modelName)
+    return this.modelConfigs[modelType] || this.modelConfigs['llama']
+  }
+
+  // Get optimized parameters for different models
+  getOptimizedParams(modelName, baseParams = {}) {
+    const modelType = this.detectModelType(modelName)
+
+    const optimizations = {
+      gemma: {
+        temperature: 0.7,
+        top_p: 0.9,
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+      },
+      qwen: {
+        temperature: 0.8,
+        top_p: 0.9,
+        repetition_penalty: 1.1,
+      },
+      deepseek: {
+        temperature: 0.7,
+        top_p: 0.9,
+        max_tokens: 4096,
+      },
+      llama: {
+        temperature: 0.8,
+        top_p: 0.9,
+        frequency_penalty: 0.0,
+      },
+      mistral: {
+        temperature: 0.7,
+        top_p: 0.9,
+        max_tokens: 4096,
+      },
+    }
+
+    return {
+      ...baseParams,
+      ...(optimizations[modelType] || optimizations['llama']),
+    }
+  }
+
+  // Process individual chunks based on model configuration
+  processChunk(chunk, config, onUpdate) {
+    try {
+      if (chunk.startsWith('data: ')) {
+        chunk = chunk.slice(6)
+      }
+
+      if (chunk === '[DONE]' || chunk === 'data: [DONE]') {
+        return
+      }
+
+      let parsed
+      try {
+        parsed = JSON.parse(chunk)
+      } catch {
+        // If it's not valid JSON and we're filtering metadata, try to extract just the response part
+        if (config.filterMetadata) {
+          const responseMatch = chunk.match(/"response":"([^"]*)"/)
+          if (responseMatch) {
+            onUpdate(responseMatch[1])
+            return
+          }
+        }
+        // Otherwise treat as raw text
+        console.warn('Invalid JSON chunk, treating as raw text:', chunk)
+        onUpdate(chunk)
+        return
+      }
+
+      let textDelta = ''
+
+      // Handle metadata filtering for models that need it (like Qwen)
+      if (config.filterMetadata && config.metadataFields) {
+        // Only extract the response field and ignore metadata
+        if (parsed[config.responseField]) {
+          textDelta = parsed[config.responseField]
+        }
+      } else {
+        // Normal processing for other models
+        if (parsed[config.responseField]) {
+          textDelta = parsed[config.responseField]
+        } else if (parsed.choices && parsed.choices[0]) {
+          textDelta = parsed.choices[0].delta?.content || parsed.choices[0].text || ''
+        } else if (parsed.content) {
+          textDelta = parsed.content
+        } else if (parsed.text) {
+          textDelta = parsed.text
+        } else if (parsed.message && parsed.message.content) {
+          textDelta = parsed.message.content
+        }
+      }
+
+      if (config.requiresSpecialParsing) {
+        textDelta = this.applySpecialParsing(textDelta, config)
+      }
+
+      if (textDelta && onUpdate) {
+        onUpdate(textDelta)
+      }
+    } catch (error) {
+      console.error('Error processing chunk:', error, chunk)
+    }
+  }
+
+  // Apply special parsing for certain models
+  applySpecialParsing(text, config) {
+    switch (config.markdownMode) {
+      case 'code-aware':
+        return this.fixCodeBlockParsing(text)
+      case 'tolerant':
+        return this.applyTolerantParsing(text)
+      default:
+        return text
+    }
+  }
+
+  // Fix code block parsing issues
+  fixCodeBlockParsing(text) {
+    if (text.includes('```') && !text.match(/```[\s\S]*?```/)) {
+      text = text.replace(/```([^`]*?)$/, '```$1\n')
+    }
+    return text
+  }
+
+  // Apply tolerant parsing for models with markdown issues
+  applyTolerantParsing(text) {
+    text = text.replace(/\*\*([^*]+)$/, '**$1**')
+    text = text.replace(/\*([^*]+)$/, '*$1*')
+    text = text.replace(/```([^`]+)$/, '```$1\n```')
+    return text
+  }
+}
+
+// Create a singleton instance
+const ollamaHandler = new OllamaStreamHandler()
+
 /**
  * Format the AI request based on provider and conversation history
  */
@@ -58,6 +317,7 @@ const formatChatRequest = (
   systemPrompt = DEFAULT_SYSTEM_PROMPT,
   version,
   customModel,
+  stream = false,
 ) => {
   // Get the actual model version to use
   const modelToUse =
@@ -81,6 +341,7 @@ const formatChatRequest = (
       max_tokens: 4000,
       system: systemMessage,
       messages: userAssistantMessages,
+      stream: stream,
     }
   }
 
@@ -90,6 +351,7 @@ const formatChatRequest = (
       model: modelToUse,
       max_tokens: 4000,
       messages: [{ role: 'system', content: systemPrompt }, ...messages],
+      stream: stream,
     }
   }
 
@@ -98,6 +360,7 @@ const formatChatRequest = (
     return {
       model: modelToUse,
       messages: [{ role: 'system', content: systemPrompt }, ...messages],
+      stream: stream,
     }
   }
 
@@ -112,6 +375,44 @@ const formatChatRequest = (
     return {
       model: modelToUse,
       contents: [{ role: 'user', parts: [{ text: systemPrompt }] }, ...geminiMessages],
+      stream: stream,
+    }
+  }
+
+  // Format for Ollama
+  else if (provider === 'ollama') {
+    // Convert messages array to Ollama format
+    let prompt = ''
+
+    // Add system message as a header if it exists
+    const systemMessage = messages.find((msg) => msg.role === 'system')?.content || systemPrompt
+    if (systemMessage) {
+      prompt += `System: ${systemMessage}\n\n`
+    }
+
+    // Add user and assistant messages in alternating format
+    for (const msg of messages.filter((m) => m.role !== 'system')) {
+      if (msg.role === 'user') {
+        prompt += `User: ${msg.content}\n\n`
+      } else if (msg.role === 'assistant') {
+        prompt += `Assistant: ${msg.content}\n\n`
+      }
+    }
+
+    // For Ollama, use the version field as the model name if provided
+    const modelToUse = version || customModel || CHAT_MODEL_MAPPINGS.ollama
+
+    // Get model-specific optimized parameters
+    const optimizedParams = ollamaHandler.getOptimizedParams(modelToUse, {
+      temperature: 0.7,
+      top_p: 0.9,
+    })
+
+    return {
+      model: modelToUse,
+      prompt: prompt.trim(),
+      stream: stream,
+      options: optimizedParams,
     }
   }
 
@@ -120,6 +421,7 @@ const formatChatRequest = (
     return {
       model: modelToUse,
       messages: [{ role: 'system', content: systemPrompt }, ...messages],
+      stream: stream,
     }
   }
 }
@@ -169,6 +471,11 @@ const getHeaders = (provider, apiKey, customHeaders) => {
       'Content-Type': 'application/json',
       'x-goog-api-key': apiKey,
     }
+  } else if (provider === 'ollama') {
+    // Ollama doesn't require authentication
+    return {
+      'Content-Type': 'application/json',
+    }
   } else {
     // Generic headers for other providers
     return {
@@ -190,6 +497,13 @@ const extractResponseText = (provider, data) => {
     return data.choices[0].message.content
   } else if (provider === 'gemini-1.5-pro') {
     return data.candidates[0].content.parts[0].text
+  } else if (provider === 'ollama') {
+    // Ollama streaming returns objects with a 'response' field
+    if (data.response) {
+      return data.response
+    }
+    // For non-streaming, it may have different format
+    return data.response || data.message?.content || ''
   } else if (provider === 'other') {
     // Try to extract from common response formats
     try {
@@ -222,6 +536,347 @@ const extractResponseText = (provider, data) => {
     return data.choices && data.choices[0] && data.choices[0].message
       ? data.choices[0].message.content
       : JSON.stringify(data)
+  }
+}
+
+/**
+ * Process streaming response chunks based on provider
+ */
+export const processStreamChunk = (chunk, provider, version, customModel) => {
+  try {
+    // For OpenAI - uses SSE format
+    if (provider.startsWith('gpt')) {
+      const chunkStr = chunk.toString()
+      // Skip empty chunks
+      if (!chunkStr.trim()) return ''
+
+      let content = ''
+      // Split the chunk into lines (SSE format sends one event per line)
+      const lines = chunkStr.split('\n')
+
+      for (const line of lines) {
+        // Skip empty lines or the "DONE" marker
+        if (!line.trim() || line.includes('[DONE]')) continue
+
+        // Process lines that start with "data: "
+        if (line.startsWith('data:')) {
+          try {
+            const jsonData = line.replace(/^data:\s*/, '').trim()
+            // Skip empty data
+            if (!jsonData) continue
+
+            // Parse the JSON data
+            const data = JSON.parse(jsonData)
+            // Extract the delta content if available
+            const deltaContent = data.choices?.[0]?.delta?.content
+            if (deltaContent) {
+              content += deltaContent
+            }
+          } catch (err) {
+            // Ignore JSON parse errors for non-JSON lines
+            console.debug('Skipping invalid JSON in OpenAI stream:', err.message)
+          }
+        }
+      }
+
+      return content
+    }
+    // For Claude
+    else if (provider.startsWith('claude')) {
+      // Claude may also use SSE format
+      if (chunk.toString().includes('event:')) {
+        const lines = chunk.toString().split('\n')
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            try {
+              const jsonData = line.slice(5).trim()
+              if (jsonData) {
+                const data = JSON.parse(jsonData)
+                return data.delta?.text || ''
+              }
+            } catch (err) {
+              // Skip invalid JSON
+              console.warn('Skipping invalid JSON in Claude stream:', line, err.message)
+            }
+          }
+        }
+        return ''
+      } else {
+        // Try to parse as direct JSON
+        try {
+          const data = JSON.parse(chunk)
+          return data.delta?.text || ''
+        } catch (err) {
+          console.warn('Failed to parse Claude response as JSON:', err.message)
+          return ''
+        }
+      }
+    }
+    // For Mistral
+    else if (provider === 'mistral-large') {
+      // Mistral may also use SSE format
+      if (chunk.toString().includes('data:')) {
+        const lines = chunk.toString().split('\n')
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            try {
+              const jsonData = line.slice(5).trim()
+              if (jsonData) {
+                const data = JSON.parse(jsonData)
+                return data.choices?.[0]?.delta?.content || ''
+              }
+            } catch (err) {
+              // Skip invalid JSON
+              console.warn('Skipping invalid JSON in Mistral stream:', line, err.message)
+            }
+          }
+        }
+        return ''
+      } else {
+        // Try to parse as direct JSON
+        try {
+          const data = JSON.parse(chunk)
+          return data.choices?.[0]?.delta?.content || ''
+        } catch (err) {
+          console.warn('Failed to parse Mistral response as JSON:', err.message)
+          return ''
+        }
+      }
+    }
+    // For Ollama
+    else if (provider === 'ollama') {
+      try {
+        const modelToUse = version || customModel || CHAT_MODEL_MAPPINGS.ollama
+        const config = ollamaHandler.getModelConfig(modelToUse)
+
+        let content = ''
+        ollamaHandler.processChunk(chunk, config, (text) => {
+          content += text
+        })
+        return content
+      } catch (err) {
+        console.warn('Failed to parse Ollama response as JSON:', err.message)
+        return ''
+      }
+    }
+    // For other providers - try multiple formats
+    else {
+      // First check if it's using SSE format
+      if (chunk.toString().includes('data:')) {
+        const lines = chunk.toString().split('\n')
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            try {
+              const jsonData = line.slice(5).trim()
+              if (jsonData) {
+                const data = JSON.parse(jsonData)
+                return (
+                  data.choices?.[0]?.delta?.content ||
+                  data.delta?.text ||
+                  data.content?.[0]?.text ||
+                  ''
+                )
+              }
+            } catch (err) {
+              // Skip invalid JSON
+              console.warn('Skipping invalid JSON in stream:', line, err.message)
+            }
+          }
+        }
+        return ''
+      }
+
+      // Otherwise try to parse as direct JSON
+      try {
+        const data = JSON.parse(chunk)
+        // Try to extract from common stream formats
+        return (
+          data.choices?.[0]?.delta?.content || data.delta?.text || data.content?.[0]?.text || ''
+        )
+      } catch (err) {
+        // If not valid JSON, it might be a chunk of text
+        console.warn('Not valid JSON, treating as raw text chunk:', err.message)
+        return chunk.toString()
+      }
+    }
+  } catch (err) {
+    console.error('Error processing stream chunk:', err)
+    return ''
+  }
+}
+
+/**
+ * Stream a chat message with real-time updates
+ */
+export const streamChatMessage = async (
+  messages,
+  provider,
+  apiKey,
+  systemPrompt,
+  version = '',
+  customModel = '',
+  customEndpoint = '',
+  customHeaders = '',
+  topic,
+  onChunk, // Callback function to receive incremental updates
+) => {
+  if (!apiKey) {
+    throw new Error('API key is required')
+  }
+
+  // Get endpoint - use custom endpoint if provider is 'other'
+  let endpoint = API_ENDPOINTS[provider]
+  if (provider === 'other') {
+    if (!customEndpoint) {
+      throw new Error('Custom endpoint is required for custom provider')
+    }
+    endpoint = customEndpoint
+  }
+
+  if (!endpoint) {
+    throw new Error(`Unsupported AI provider: ${provider}`)
+  }
+
+  // Use provided system prompt or generate one with the current topic
+  const actualSystemPrompt = systemPrompt || getSystemPrompt(topic)
+
+  const requestData = formatChatRequest(
+    provider,
+    messages,
+    actualSystemPrompt,
+    version,
+    customModel,
+    true, // Enable streaming
+  )
+
+  const headers = getHeaders(provider, apiKey, customHeaders)
+
+  try {
+    if (isDevelopment) {
+      console.log('Using direct API call with streaming in development mode')
+
+      // Use fetch for better streaming support
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(requestData),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(`API error: ${errorData.message || response.statusText}`)
+      }
+
+      // Handle streaming based on provider
+      const decoder = new TextDecoder()
+      let fullText = ''
+
+      if (response.body) {
+        const reader = response.body.getReader()
+
+        // For OpenAI, Claude, and others that support SSE
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+
+            const chunk = decoder.decode(value, { stream: true })
+            // Log raw chunk for debugging
+            if (chunk.length > 0) {
+              console.debug(
+                'Raw chunk:',
+                chunk.substring(0, 100) + (chunk.length > 100 ? '...' : ''),
+              )
+            }
+
+            const content = processStreamChunk(chunk, provider, version, customModel)
+
+            if (content) {
+              fullText += content
+              onChunk(content)
+            }
+          }
+
+          return fullText
+        } catch (err) {
+          console.error('Stream processing error:', err)
+          throw new Error(`Stream processing error: ${err.message}`)
+        }
+      } else {
+        throw new Error('ReadableStream not supported by your browser')
+      }
+    } else {
+      // In production, use our proxy with streaming
+      try {
+        const response = await fetch(PROXY_API_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            target: endpoint,
+            data: requestData,
+            headers: headers,
+            stream: true,
+          }),
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw new Error(`API error: ${errorData.message || response.statusText}`)
+        }
+
+        if (!response.body) {
+          throw new Error('ReadableStream not supported by your browser')
+        }
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let fullText = ''
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+
+            const chunk = decoder.decode(value, { stream: true })
+            const content = processStreamChunk(chunk, provider, version, customModel)
+
+            if (content) {
+              fullText += content
+              onChunk(content)
+            }
+          }
+
+          return fullText
+        } catch (err) {
+          console.error('Stream processing error:', err)
+          throw new Error(`Stream processing error: ${err.message}`)
+        }
+      } catch (error) {
+        console.warn('Streaming error, falling back to regular request:', error)
+        // Fallback to non-streaming if there's an error
+        return await sendChatMessage(
+          messages,
+          provider,
+          apiKey,
+          systemPrompt,
+          version,
+          customModel,
+          customEndpoint,
+          customHeaders,
+          topic,
+        )
+      }
+    }
+  } catch (error) {
+    console.error('AI Chat API error:', error)
+    const errorMsg =
+      error.response?.data?.error?.message ||
+      error.response?.data?.message ||
+      error.message ||
+      'An unknown error occurred'
+    throw new Error(`AI chat service error: ${errorMsg}`)
   }
 }
 
@@ -302,6 +957,10 @@ export const sendChatMessage = async (
  */
 export const validateChatApiKey = (provider, apiKey) => {
   if (!apiKey || apiKey.trim() === '') {
+    // For Ollama, we don't need an API key
+    if (provider === 'ollama') {
+      return true
+    }
     return false
   }
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -99,7 +99,7 @@
         This curriculum is specifically designed to help you succeed in interviews for:
       </p>
       <div class="row">
-        <div class="col-md-4">
+        <div class="col-md-4 mb-3">
           <div class="job-card">
             <div class="job-icon">
               <i class="bi bi-globe"></i>
@@ -108,7 +108,7 @@
             <p>Master DOM manipulation, event handling, and modern frameworks.</p>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-4 mb-3">
           <div class="job-card">
             <div class="job-icon">
               <i class="bi bi-stack"></i>
@@ -117,7 +117,7 @@
             <p>Balance client-side expertise with server-side knowledge.</p>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-4 mb-3">
           <div class="job-card">
             <div class="job-icon">
               <i class="bi bi-code-square"></i>
@@ -293,8 +293,6 @@ onMounted(async () => {
   await loadCurriculum()
   await calculateProgress()
   await updateSectionCompletionMap()
-
-  console.log('Available topics with curriculum:', topicStore.topicsWithCurriculum)
 })
 
 // Watch for topic changes to reload the curriculum


### PR DESCRIPTION
# AI Chat & Sidebar Menu Enhancements + UI/UX Improvements

## Major Changes

### AI Chat System Updates
- Implemented streaming responses for AI chat interactions.
  - Added option to enable/disable streaming in chat options section.
  - Added Implementation of markdown-to-HMTL for streaming chunks in real time.
  - Fixed dark mode text color in AI Chat message input and background color of the Send button.
- Added support for additional AI providers and models:
  - OpenAI (GPT-4.5, GPT-o3, GPT-o4-mini)
  - Anthropic (Claude 3.5/3.7 Sonnet, Claude 3 Opus/Haiku, Claude Opus/Sonnet 4)
  - Google (Gemini 1.5/2.5 Pro, Gemini 2.5 Flash)
  - DeepSeek (Reasoner, R1 Distill)
  - Mistral (Large, Large 2)
  - Llama (3, 3.1, 3.2)
  - Cohere (Command R+)
  - Ollama (Local)
  - Qwen 2.5
  - Grok 3
- Added configurable endpoints for each provider
- Note: Currently tested with GPT, Claude, and Ollama models only

### Sidebar UX Improvements
- Added draggable resize handle for sidebar width adjustment
  - Smooth collapse/expand transitions
  - Visual feedback on hover
  - Mobile-optimized (disabled on mobile)

## Testing Notes
- AI Chat: Tested with GPT, Claude, and Ollama models
  - Streaming AI responses work reasonable well
  - Markdown is converted to appropriate HTML markup
- Sidebar: Tested on desktop with mouse and touch input
- Mobile: Verified sidebar behavior on mobile devices
- Dark/Light mode: Verified text visibility in both themes

## Future Considerations
- Additional AI model testing needed for untested providers
- Considering adding additional model-specific configuration options