### PR TITLE
Chatbot Settings Panel, & AI Lesson Aid - Improvements

### DIFF
--- a/src/components/AIChat.vue
+++ b/src/components/AIChat.vue
@@ -127,13 +127,14 @@
               related to your coding lessons. I'm here to help you learn!
             </p>
             <div v-if="!aiChatStore.apiKey" class="api-key-warning">
-              <i class="bi bi-exclamation-triangle-fill me-2"></i>
-              <span
-                >You need to configure an API key in settings to get started.
-                <button @click="showSettings = true" class="btn-link">
-                  <i class="bi bi-gear"></i> Configure Settings
-                </button>
-              </span>
+              <div class="api-key-warning__text">
+                <i class="bi bi-exclamation-triangle-fill"></i>
+                <span>Add an API key to start chatting with Preppy.</span>
+              </div>
+              <button @click="showSettings = true" class="api-key-warning__btn" type="button">
+                <i class="bi bi-gear"></i>
+                <span>Configure AI Settings</span>
+              </button>
             </div>
           </div>
 
@@ -167,7 +168,7 @@
 
       <!-- Settings panel -->
       <div v-else class="settings-container">
-        <ChatSettings />
+        <ChatSettings @back="showSettings = false" />
       </div>
     </div>
   </div>
@@ -711,29 +712,69 @@ onUnmounted(() => {
 }
 
 .api-key-warning {
-  margin-top: 15px;
-  padding: 10px;
-  background-color: rgba(var(--warning-color-rgb, 255, 193, 7), 0.1);
-  border-radius: 6px;
-  font-size: 0.8rem;
-  color: var(--warning-color);
-  text-align: left;
+  margin-top: 16px;
+  padding: 14px;
+  background-color: rgba(var(--warning-color-rgb, 245, 158, 11), 0.08);
+  border: 1px solid rgba(var(--warning-color-rgb, 245, 158, 11), 0.35);
+  border-radius: 8px;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  text-align: left;
 }
 
-.btn-link {
-  background: none;
-  border: none;
-  color: #4f46e5;
-  padding: 0;
-  font-size: inherit;
-  text-decoration: underline;
+.api-key-warning__text {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text-color);
+}
+
+.api-key-warning__text i {
+  color: var(--warning-color);
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.api-key-warning__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1.2;
+  border: 1px solid var(--primary-color);
+  border-radius: 6px;
+  background-color: var(--primary-color);
+  color: #ffffff;
   cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
 }
 
-.btn-link:hover {
-  color: #4338ca;
+.api-key-warning__btn:hover {
+  background-color: var(--primary-color-dark);
+  border-color: var(--primary-color-dark);
+}
+
+.api-key-warning__btn:active {
+  transform: translateY(1px);
+}
+
+.api-key-warning__btn:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+body.dark-mode .api-key-warning__btn {
+  color: #111827;
+}
+
+body.dark-mode .api-key-warning__btn:hover {
+  color: #ffffff;
 }
 
 .typing-indicator {

--- a/src/components/ChatSettings.vue
+++ b/src/components/ChatSettings.vue
@@ -183,7 +183,7 @@
           @click="showConfirm('save')"
           class="btn"
           :class="saveButtonClass"
-          :disabled="isSaving || (provider !== 'ollama' && !apiKey)"
+          :disabled="!canSave"
         >
           <span v-if="isSaving">
             <span
@@ -196,6 +196,14 @@
           <span v-else>
             {{ saveStatus || 'Save Settings' }}
           </span>
+        </button>
+        <button
+          @click="emit('back')"
+          class="btn btn-back"
+          type="button"
+          title="Return to the chat"
+        >
+          Back to Chat
         </button>
         <button
           v-if="aiChatStore.apiKey"
@@ -231,8 +239,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useAIChatStore } from '../store/aiChat'
 import { testChatApiConnection } from '../utils/aiChatService'
+import { getProvider } from '../utils/aiProviders'
 import TermsAndConditions from './TermsAndConditions.vue'
 import ConfirmDialog from './ConfirmDialog.vue'
+
+const emit = defineEmits(['back'])
 
 const aiChatStore = useAIChatStore()
 
@@ -257,27 +268,54 @@ const termsAccepted = ref(false)
 const isTesting = ref(false)
 
 // Computed properties
-const saveButtonClass = computed(() => {
-  if (saveStatus.value === 'Saved Successfully') {
-    return 'btn-success'
-  } else if (saveStatus.value === 'Invalid API Key' || saveStatus.value === 'Connection Failed') {
-    return 'btn-danger'
-  } else {
-    return 'btn-secondary'
+
+// Required fields are filled in and we're ready to attempt a save.
+// Drives both the btn-success cue and the :disabled gate on the button.
+const canSave = computed(() => {
+  if (isSaving.value) return false
+  if (!termsAccepted.value) return false
+  if (!version.value || !version.value.trim()) return false
+  if (provider.value === 'ollama') return true
+  if (!apiKey.value || !apiKey.value.trim()) return false
+  if (provider.value === 'other') {
+    if (!customEndpoint.value || !customEndpoint.value.startsWith('http')) return false
+    if (!customModel.value || !customModel.value.trim()) return false
   }
+  return true
+})
+
+const ERROR_STATUSES = new Set([
+  'Invalid API Key',
+  'Connection Failed',
+  'Invalid Endpoint',
+  'Model Required',
+  'Terms Required',
+])
+
+const saveButtonClass = computed(() => {
+  if (saveStatus.value === 'Saved Successfully') return 'btn-success'
+  if (ERROR_STATUSES.has(saveStatus.value)) return 'btn-danger'
+  if (canSave.value) return 'btn-success'
+  return 'btn-secondary'
 })
 
 const handleProviderChange = () => {
   saveStatus.value = ''
 
-  if (aiChatStore.isCustomProvider) {
+  if (provider.value === 'other') {
     customModel.value = aiChatStore.customModel || ''
     customEndpoint.value = aiChatStore.customEndpoint || ''
     customHeaders.value = aiChatStore.customHeaders || ''
+    // Custom provider uses `customModel`, not `version` — leave version alone.
   } else if (provider.value === 'ollama') {
-    // For Ollama, use the current version, no key is required
-    version.value = aiChatStore.version || ''
+    // Preserve any previously-entered local model name; fall back to the
+    // catalogue default if the user has never set one.
+    version.value = aiChatStore.version || getProvider(provider.value)?.model || ''
     apiKey.value = 'OLLAMA-LOCAL-NO-KEY-REQUIRED'
+  } else {
+    // Auto-populate the version field with the selected provider's default
+    // model id. The input stays editable so users can override.
+    version.value = getProvider(provider.value)?.model || ''
   }
 }
 
@@ -447,6 +485,12 @@ onMounted(() => {
   termsAccepted.value = aiChatStore.termsAccepted
   streamingEnabled.value = aiChatStore.useStreaming
   showAlert.value = !aiChatStore.apiKey
+
+  // First visit (or stored settings with no version): seed from the
+  // catalogue so the Model Version field isn't blank out of the gate.
+  if (!version.value && provider.value !== 'other') {
+    version.value = getProvider(provider.value)?.model || ''
+  }
 })
 </script>
 
@@ -486,6 +530,33 @@ onMounted(() => {
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
+}
+
+.settings-back {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-color);
+}
+
+.btn-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background-color: transparent;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-back:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.1);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.btn-back:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 /* dark mode form controls */

--- a/src/components/LessonAIActions.vue
+++ b/src/components/LessonAIActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lesson-ai-actions" v-if="hasApiKey">
+  <div class="lesson-ai-actions">
     <span class="lesson-ai-actions__label">
       <i class="bi bi-magic"></i>
       Ask Preppy:
@@ -20,7 +20,6 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
 import { useAIChatStore } from '../store/aiChat'
 import { useTopicStore } from '../store/topic'
 import { LESSON_QUICK_ACTIONS } from '../utils/aiPrompts'
@@ -36,10 +35,15 @@ const aiChatStore = useAIChatStore()
 const topicStore = useTopicStore()
 const actions = LESSON_QUICK_ACTIONS
 
-const hasApiKey = computed(() => !!aiChatStore.apiKey && aiChatStore.apiKey.trim() !== '')
-
 async function runAction(action) {
   if (aiChatStore.isSending) return
+  const hasApiKey = !!aiChatStore.apiKey && aiChatStore.apiKey.trim() !== ''
+  // No key configured — open the chat so its landing view prompts the
+  // user to configure. Skip the send; we don't want a silent failure.
+  if (!hasApiKey) {
+    aiChatStore.openChat()
+    return
+  }
   const ctx = {
     topic: topicStore.currentTopicName,
     sectionTitle: props.sectionTitle,


### PR DESCRIPTION
# Chatbot Settings Panel, & AI Lesson Aid - Improvements

## Summary
Updates to the Chatbot Settings Panel and AI Lesson Aid improve feature discoverability by enabling the "Ask Preppy" action to render immediately, directing users to configuration options if API keys are missing. Enhancements include a more prominent configuration button in the AIChat component, improved visual styling, and streamlined navigation within the ChatSettings panel, which now features automatic model version population and improved validation logic for saving settings.

### `src/components/LessonAIActions.vue`
  - Removed the `v-if="hasApiKey"` gate so the **"Ask Preppy"** action row always renders on lesson pages — users can now discover the feature before configuring an AI provider.                                                                                                               
  - Moved the key check into `runAction`: if no key is set, we just `openChat()` (whose landing view already prompts the user to configure) instead of firing a silent send.
  - Dropped the now-unused `computed` import and `hasApiKey` ref.

  ### `src/components/AIChat.vue`
  - Replaced the inline underlined "Configure Settings" text-link in the welcome view with a proper primary **"Configure AI Settings"** button (icon + label on its own row).
  - Restyled the `.api-key-warning` panel to theme via `--warning-color-rgb` with a clearer border, so it reads in both light and dark mode.       
  - New `.api-key-warning__btn` uses `--primary-color` / `--primary-color-dark` with a proper `:focus-visible` outline.
  - Wired the new `@back` event from `<ChatSettings />` to flip `showSettings = false`.

  ### `src/components/ChatSettings.vue`
  - **Back-to-Chat button** — added at the bottom of the panel alongside Save / Delete API Key (a secondary, theme-aware `.btn-back` style with a  `--primary-color` tinted hover). Emits a `back` event handled by `AIChat.vue`.
  - **Save Settings goes green when ready** — new `canSave` computed gates both `saveButtonClass` and `:disabled`. Checks terms, version, API key (skipped for Ollama), and endpoint/model (for custom). Existing "Saved Successfully" / error-state overrides kept.
  - **Model Version auto-populates from the selected provider** — on dropdown change, `handleProviderChange` pulls the provider's default `model` from `aiProviders.getProvider()` into the `version` field. Field stays editable. Ollama preserves any local model name the user has already      
  entered.
    - `onMounted` seeds `version` from the catalogue when the stored value is empty, so the field isn't blank on first visit.
    - Fixed `handleProviderChange` to check `provider.value === 'other'` instead of `aiChatStore.isCustomProvider` — the store only updates on save,  so the custom branch never actually ran during a dropdown change.
 - Expanded `ERROR_STATUSES` set so `Invalid Endpoint` / `Model Required` / `Terms Required` also tint the button red.